### PR TITLE
Travis CI: upgrade build OS to Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy"
 
 install:
   - pip install --requirement requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  # - "pypy"  # disable pypy builds until supported by trusty containers
 
 install:
   - pip install --requirement requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: false
 language: python
 
 python:


### PR DESCRIPTION
Should improve build time on Travis. As per https://docs.travis-ci.com/user/trusty-ci-environment/:

> The advantage of running with sudo: false is dramatically reduced time between commit push to GitHub and the start of a job on Travis CI, which works especially well when one’s average job duration is under 3 minutes.

