### PR TITLE
Add minlen feature to base62.encode()

### DIFF
--- a/base62.py
+++ b/base62.py
@@ -31,22 +31,24 @@ def bytes_to_int(s, byteorder='big', signed=False):
         return sum(ds)
 
 
-def encode(n):
+def encode(n, minlen=0):
     """Encodes a given integer ``n``."""
 
-    s = []
+    chs = []
     while n > 0:
         r = n % BASE
         n //= BASE
 
-        s.append(CHARSET[r])
+        chs.append(CHARSET[r])
 
-    if len(s) > 0:
-        s.reverse()
+    if len(chs) > 0:
+        chs.reverse()
     else:
-        s.append('0')
+        chs.append('0')
 
-    return ''.join(s)
+    s = ''.join(chs)
+    s = CHARSET[0] * max(minlen - len(s), 0) + s
+    return s
 
 
 def encodebytes(s):

--- a/base62.py
+++ b/base62.py
@@ -93,13 +93,9 @@ def decodebytes(s):
 def __value__(ch):
     """Decodes an individual digit of a base62 encoded string."""
 
-    if ch in '01234567890':
-        return ord(ch) - ord('0')
-    elif ch in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ':
-        return ord(ch) - ord('A') + 10
-    elif ch in 'abcdefghijklmnopqrstuvwxyz':
-        return ord(ch) - ord('a') + 36
-    else:
+    try:
+        return CHARSET.index(ch)
+    except ValueError:
         raise ValueError('base62: Invalid character (%s)' % ch)
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -17,6 +17,7 @@ def test_basic():
     assert base62.encode(0) == '0'
     assert base62.encode(0, minlen=5) == '00000'
     assert base62.decode('0') == 0
+    assert base62.decode('000001') == 1
 
     assert base62.encode(34441886726) == 'base62'
     assert base62.decode('base62') == 34441886726

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -15,6 +15,7 @@ bytes_int_pairs = [
 
 def test_basic():
     assert base62.encode(0) == '0'
+    assert base62.encode(0, minlen=5) == '00000'
     assert base62.decode('0') == 0
 
     assert base62.encode(34441886726) == 'base62'


### PR DESCRIPTION
This PR will add minlen feature. In other words, it does zero padding for encode output string.

This implementation (and naming) is copied from the famous and widely used python bitcoin library 
[pybitcointools](https://github.com/vbuterin/pybitcointools) : 

https://github.com/vbuterin/pybitcointools/blob/a82b00686b51677b047098e8968074a783e054a1/bitcoin/py2specials.py
