### PR TITLE
Allow inverted charset

### DIFF
--- a/base62.py
+++ b/base62.py
@@ -11,7 +11,7 @@ __author__ = 'Sumin Byeon'
 __email__ = 'suminb@gmail.com'
 __version__ = '0.3.3'
 
-CHARSET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+CHARSET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 BASE = 62
 
 

--- a/base62.py
+++ b/base62.py
@@ -9,10 +9,15 @@ Originated from http://blog.suminb.com/archives/558
 __title__ = 'base62'
 __author__ = 'Sumin Byeon'
 __email__ = 'suminb@gmail.com'
-__version__ = '0.3.3'
+__version__ = '0.4.0'
 
-CHARSET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 BASE = 62
+CHARSET_DEFAULT = (
+    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+)
+CHARSET_INVERTED = (
+    '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+)
 
 
 def bytes_to_int(s, byteorder='big', signed=False):
@@ -36,7 +41,7 @@ def bytes_to_int(s, byteorder='big', signed=False):
         return sum(ds)
 
 
-def encode(n, minlen=1):
+def encode(n, minlen=1, charset=CHARSET_DEFAULT):
     """Encodes a given integer ``n``."""
 
     chs = []
@@ -44,7 +49,7 @@ def encode(n, minlen=1):
         r = n % BASE
         n //= BASE
 
-        chs.append(CHARSET[r])
+        chs.append(charset[r])
 
     if len(chs) > 0:
         chs.reverse()
@@ -52,21 +57,21 @@ def encode(n, minlen=1):
         chs.append('0')
 
     s = ''.join(chs)
-    s = CHARSET[0] * max(minlen - len(s), 0) + s
+    s = charset[0] * max(minlen - len(s), 0) + s
     return s
 
 
-def encodebytes(s):
+def encodebytes(s, charset=CHARSET_DEFAULT):
     """Encodes a bytestring into a base62 string.
 
     :param s: A byte array
     """
 
     _check_bytes_type(s)
-    return encode(bytes_to_int(s))
+    return encode(bytes_to_int(s), charset=charset)
 
 
-def decode(b):
+def decode(b, charset=CHARSET_DEFAULT):
     """Decodes a base62 encoded value ``b``."""
 
     if b.startswith('0z'):
@@ -74,20 +79,20 @@ def decode(b):
 
     l, i, v = len(b), 0, 0
     for x in b:
-        v += _value(x) * (BASE ** (l - (i + 1)))
+        v += _value(x, charset=charset) * (BASE ** (l - (i + 1)))
         i += 1
 
     return v
 
 
-def decodebytes(s):
+def decodebytes(s, charset=CHARSET_DEFAULT):
     """Decodes a string of base62 data into a bytes object.
 
     :param s: A string to be decoded in base62
     :rtype: bytes
     """
 
-    decoded = decode(s)
+    decoded = decode(s, charset=charset)
     buf = bytearray()
     while decoded > 0:
         buf.append(decoded & 0xff)
@@ -97,11 +102,11 @@ def decodebytes(s):
     return bytes(buf)
 
 
-def _value(ch):
+def _value(ch, charset):
     """Decodes an individual digit of a base62 encoded string."""
 
     try:
-        return CHARSET.index(ch)
+        return charset.index(ch)
     except ValueError:
         raise ValueError('base62: Invalid character (%s)' % ch)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -26,13 +26,13 @@ def test_basic():
     assert base62.decode('0000') == 0
     assert base62.decode('000001') == 1
 
-    assert base62.encode(34441886726) == 'base62'
-    assert base62.decode('base62') == 34441886726
+    assert base62.encode(10231951886) == 'base62'
+    assert base62.decode('base62') == 10231951886
 
     # NOTE: For backward compatibility. When I first wrote this module in PHP,
     # I used to use the `0z` prefix to denote a base62 encoded string (similar
     # to `0x` for hexadecimal strings).
-    assert base62.decode('0zbase62') == 34441886726
+    assert base62.decode('0zbase62') == 10231951886
 
 
 @pytest.mark.parametrize('b, i', bytes_int_pairs)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -14,7 +14,8 @@ bytes_int_pairs = [
 
 
 def test_const():
-    assert len(base62.CHARSET) == base62.BASE == 62
+    assert len(base62.CHARSET_DEFAULT) == base62.BASE == 62
+    assert len(base62.CHARSET_INVERTED) == base62.BASE == 62
 
 
 def test_basic():
@@ -26,13 +27,33 @@ def test_basic():
     assert base62.decode('0000') == 0
     assert base62.decode('000001') == 1
 
-    assert base62.encode(10231951886) == 'base62'
-    assert base62.decode('base62') == 10231951886
+    assert base62.encode(34441886726) == 'base62'
+    assert base62.decode('base62') == 34441886726
 
     # NOTE: For backward compatibility. When I first wrote this module in PHP,
     # I used to use the `0z` prefix to denote a base62 encoded string (similar
     # to `0x` for hexadecimal strings).
-    assert base62.decode('0zbase62') == 10231951886
+    assert base62.decode('0zbase62') == 34441886726
+
+
+def test_basic_inverted():
+    kwargs = {'charset': base62.CHARSET_INVERTED}
+
+    assert base62.encode(0, **kwargs) == '0'
+    assert base62.encode(0, minlen=0, **kwargs) == '0'
+    assert base62.encode(0, minlen=1, **kwargs) == '0'
+    assert base62.encode(0, minlen=5, **kwargs) == '00000'
+    assert base62.decode('0', **kwargs) == 0
+    assert base62.decode('0000', **kwargs) == 0
+    assert base62.decode('000001', **kwargs) == 1
+
+    assert base62.encode(10231951886, **kwargs) == 'base62'
+    assert base62.decode('base62', **kwargs) == 10231951886
+
+    # NOTE: For backward compatibility. When I first wrote this module in PHP,
+    # I used to use the `0z` prefix to denote a base62 encoded string (similar
+    # to `0x` for hexadecimal strings).
+    assert base62.decode('0zbase62', **kwargs) == 10231951886
 
 
 @pytest.mark.parametrize('b, i', bytes_int_pairs)


### PR DESCRIPTION
Allow easily using an inverted charset `0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ` - some other implementations online (e.g. [this Java one](https://github.com/dukky/Base62/blob/master/base62/src/im/duk/base62/Base62.java)) use the charset in a different order. This code provides a new constant for this type of charset & allows the user to specify which charset to use on all calls (while leaving the current defaults unchanged).

I originally wrote this based on the develop branch but that has quite a few commits which are not in master so I changed it to be against master. Happy to rebase if you would prefer this PR go to develop instead.