### PR TITLE
feat: Support encoding with arbitrary charsets

### DIFF
--- a/base62.py
+++ b/base62.py
@@ -11,7 +11,6 @@ __author__ = "Sumin Byeon"
 __email__ = "suminb@gmail.com"
 __version__ = "0.4.3"
 
-BASE = 62
 CHARSET_DEFAULT = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 CHARSET_INVERTED = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
@@ -51,11 +50,12 @@ def bytes_to_int(barray, byteorder="big", signed=False):
 
 def encode(n, minlen=1, charset=CHARSET_DEFAULT):
     """Encodes a given integer ``n``."""
+    base = len(charset)
 
     chs = []
     while n > 0:
-        r = n % BASE
-        n //= BASE
+        r = n % base
+        n //= base
 
         chs.append(charset[r])
 
@@ -88,6 +88,7 @@ def decode(encoded, charset=CHARSET_DEFAULT):
     :rtype: int
     """
     _check_type(encoded, string_types)
+    base = len(charset)
 
     if encoded.startswith("0z"):
         encoded = encoded[2:]


### PR DESCRIPTION
This is just a GitHub editor spike, but I wanted to see what you thought about this. I don't see a generic "base X" library for Python analogous to e.g. [`base-x`](https://www.npmjs.com/package/base-x) for JavaScript, but it looked like it would be pretty easy to adapt this library to do that.

My proximate motivation here is just that [`base36`](https://pypi.org/project/base36/) doesn't take bytes, so the API is a bit annoying to use.