### PR TITLE
Fix Python 3.6 failing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,18 @@ on: [push]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
+        runs-on: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        include:
+          - runs-on: ubuntu-20.04
+            python-version: "3.6"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install black mypy
+        pip install -e .
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f tests/requirements.txt ]; then pip install -r tests/requirements.txt; fi
     - name: Lint with black and mypy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools wheel
         pip install black mypy
         pip install -e .
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ You may run some test cases to ensure all functionalities are operational.
 
 ::
 
-    py.test -v
+    pytest -v
 
 If ``pytest`` is not installed, you may want to run the following command:
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-pytest==3.6.1
+pytest
 pytest-cov
 coveralls


### PR DESCRIPTION
The error is caused by the latest Ubuntu runner (22.04) not having a package for Python 3.6.

This PR modifies CI to use Ubuntu 20.04 when testing Python 3.6. It also adds testing for Python 3.10 and 3.11.