### PR TITLE
Fix hardcoded zeros for `encode(0, ...)` and padding

### DIFF
--- a/base62.py
+++ b/base62.py
@@ -25,7 +25,7 @@ def encode(n, charset=CHARSET_DEFAULT):
         chs.insert(0, charset[r])
 
     if not chs:
-        return "0"
+        return charset[0]
 
     return "".join(chs)
 
@@ -50,9 +50,9 @@ def encodebytes(barray, charset=CHARSET_DEFAULT):
     # Encode the leading zeros as "0" followed by a character indicating the count.
     # This pattern may occur several times if there are many leading zeros.
     n, r = divmod(leading_zeros_count, len(charset) - 1)
-    zero_padding = f"0{charset[-1]}" * n
+    zero_padding = f"{charset[0]}{charset[-1]}" * n
     if r:
-        zero_padding += f"0{charset[r]}"
+        zero_padding += f"{charset[0]}{charset[r]}"
 
     # Special case: the input is empty, or is entirely null bytes.
     if leading_zeros_count == len(barray):
@@ -87,7 +87,7 @@ def decodebytes(encoded, charset=CHARSET_DEFAULT):
     """
 
     leading_null_bytes = b""
-    while encoded.startswith("0") and len(encoded) >= 2:
+    while encoded.startswith(charset[0]) and len(encoded) >= 2:
         leading_null_bytes += b"\x00" * _value(encoded[1], charset)
         encoded = encoded[2:]
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,6 +3,8 @@ import pytest
 import base62
 
 
+CHARSET_QWERTY = "1234567890QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm"
+
 bytes_int_pairs = [
     (b"\x01", 1),
     (b"\x01\x01", 0x0101),
@@ -37,6 +39,18 @@ def test_basic_inverted():
 
     assert base62.encode(10231951886, **kwargs) == "base62"
     assert base62.decode("base62", **kwargs) == 10231951886
+
+
+def test_basic_qwerty():
+    kwargs = {"charset": CHARSET_QWERTY}
+
+    assert base62.encode(0, **kwargs) == "1"
+    assert base62.decode("1", **kwargs) == 0
+    assert base62.decode("1111", **kwargs) == 0
+    assert base62.decode("111112", **kwargs) == 1
+
+    assert base62.encode(54742896343, **kwargs) == "base62"
+    assert base62.decode("base62", **kwargs) == 54742896343
 
 
 @pytest.mark.parametrize("b, i", bytes_int_pairs)


### PR DESCRIPTION
Currently, `decode(encode(0, charset=MY_CHARSET), charset=MY_CHARSET)` may not yield `0` due to hardcoding. This proposed change eliminates hardcoding instances and resolves the issue.